### PR TITLE
Call newer Heroku::Auth.api method to obtain config variable

### DIFF
--- a/lib/papertrail.rb
+++ b/lib/papertrail.rb
@@ -12,7 +12,9 @@ module Heroku::Command
     end
 
     def logs
-      token = heroku.config_vars(app)['PAPERTRAIL_API_TOKEN']
+      config_vars = Heroku::Auth.api.get_config_vars(app).body
+
+      token = config_vars['PAPERTRAIL_API_TOKEN']
       if token.nil? or token.empty?
         abort 'Add the Papertrail addon to this application (see https://addons.heroku.com/papertrail)'
       end


### PR DESCRIPTION
Tested against Heroku Toolbelt `heroku-toolbelt/3.4.3 (x86_64-darwin10.8.0) ruby/1.9.3` (current today) and using the same call to obtain the `api` method as multiple employee-authored plugins.
