### PR TITLE
Remove deprecated default

### DIFF
--- a/commands/pt.js
+++ b/commands/pt.js
@@ -2,6 +2,7 @@
 var h      = require('heroku-cli-util');
 var https  = require("https");
 var qs     = require("querystring");
+const co   = require("co");
 
 var tailDelay = 1000;
 
@@ -61,11 +62,11 @@ module.exports = {
   needsAuth: true,
   flags: [{name: "tail", char: "t", hasValue: false, description: "stream new logs in as they're received"}],
   args: [{name: "query", optional: true}],
-  run: h.command(function* (context, heroku) {
+  run: co.wrap(h.command(function* (context, heroku) {
     var config = yield heroku.apps(context.app).configVars().info();
     if (!config.PAPERTRAIL_API_TOKEN) {
       throw new Error("Add the Papertrail add-on to this application: https://addons.heroku.com/papertrail");
     }
     search(config.PAPERTRAIL_API_TOKEN, context.args.query, context.flags.tail);
-  })
+  }))
 };

--- a/commands/pt.js
+++ b/commands/pt.js
@@ -59,7 +59,6 @@ module.exports = {
   help: "Shows the most recent logs matching an optional search query.",
   needsApp: true,
   needsAuth: true,
-  default: true,
   flags: [{name: "tail", char: "t", hasValue: false, description: "stream new logs in as they're received"}],
   args: [{name: "query", optional: true}],
   run: h.command(function* (context, heroku) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Larry Marburger",
   "license": "MIT",
   "dependencies": {
+    "co": "^4.6.0",
     "heroku-cli-util": "^4.0.2"
   }
 }


### PR DESCRIPTION
`default: true` on commands is deprecated in CLI V6 (now stable).